### PR TITLE
fix: Notifications on Android 13+

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" /> <!-- UninstallHelper.UninstallReceiver -->
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" /> <!-- Required to start ACTION_UNINSTALL_PACKAGE since Android P -->
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" /> <!-- Notifications. This required in Android 13, see https://github.com/pppscn/SmsForwarder/issues/255 -->
+    
+    
     <application android:label="Island - Mobile"
                  android:icon="@mipmap/ic_launcher"
                  android:roundIcon="@mipmap/ic_launcher_round"


### PR DESCRIPTION
For Island 6.3

Based on https://github.com/pppscn/SmsForwarder/issues/255 ， not tested （INSTALL_FAILED_SHARED_USER_INCOMPATIBLE）

I couldn't enable Notification permission on MIUI 14, Android 13, and I saw the same problem on GitHub (It was solved, https://github.com/pppscn/SmsForwarder/commit/d2a668f635bc126bc37d959ae9b0336cc1da0974 ) so I created this PR :)

Maybe it can fix this problem
![Screenshot_2024-04-13-07-00-22-439_com android settings-edit](https://github.com/oasisfeng/island/assets/150461955/ba167d74-7246-40d5-bfbc-578114db6ccf)

Same problem (#474)
